### PR TITLE
GPU Memory

### DIFF
--- a/board/raspberrypi2/config.txt
+++ b/board/raspberrypi2/config.txt
@@ -7,4 +7,5 @@ over_voltage=0
 gpu_mem=128
 gpu_mem_256=128
 gpu_mem_512=128
+gpu_mem_1024=512
 disable_camera_led=0

--- a/board/raspberrypi2/motioneye-modules/boardctl.py
+++ b/board/raspberrypi2/motioneye-modules/boardctl.py
@@ -186,7 +186,7 @@ def gpuMem():
         'description': 'set the amount of memory reserved for the GPU (choose at least 96MB if you use the CSI camera board)',
         'type': 'number',
         'min': '16',
-        'max': '448',
+        'max': '944',
         'section': 'expertSettings',
         'advanced': True,
         'reboot': True,


### PR DESCRIPTION
I suggest to enable in expert settings, that one on Raspberry Pi 2 can raise GPU memory to max (944 MB) like documented here https://www.raspberrypi.org/documentation/configuration/config-txt.md.
I run my Raspberry Pi 2 with motioneyeos for more than two weeks with 512 MB GPU memory. It seems reliable and runs stable.
Also in config.txt I added gpu_mem_1024=512 for Raspberry Pi 2 as default configuration. 
