### PR TITLE
unmount before trying to mount_msdos

### DIFF
--- a/writeimage.sh
+++ b/writeimage.sh
@@ -90,6 +90,7 @@ mkdir -p $BOOT
 
 if [ `uname` == "Darwin" ]; then
     BOOT_DEV=${SDCARD_DEV}s1 # e.g. /dev/disk4s1
+    umount ${SDCARD_DEV}* 2>/dev/null || true
     mount_msdos $BOOT_DEV $BOOT
 else # assuming Linux
     BOOT_DEV=${SDCARD_DEV}p1 # e.g. /dev/mmcblk0p1


### PR DESCRIPTION
I've been seeing this issue https://github.com/ccrisan/motioneyeos/issues/256
which stops my wifi settings being written. Unmounting before trying to mount fixes this.