### PR TITLE
Enable Ethernet-over-USB for the Raspberry Pi (Zero).

### DIFF
--- a/board/raspberrypi/cmdline.txt
+++ b/board/raspberrypi/cmdline.txt
@@ -1,1 +1,1 @@
-dwc_otg.fiq_fix_enable=1 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait ro rootflags=noload panic=10 quiet loglevel=1 ipv6.disable=1
+dwc_otg.fiq_fix_enable=1 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait modules-load=dwc2,g_ether ro rootflags=noload panic=10 quiet loglevel=1 ipv6.disable=1

--- a/board/raspberrypi/config.txt
+++ b/board/raspberrypi/config.txt
@@ -6,4 +6,4 @@ dtparam=i2c_arm=on
 dtparam=i2s=on
 dtparam=spi=on
 dtparam=audio=on
-
+dtoverlay=dwc2


### PR DESCRIPTION
This is very handy for initial configuration.