### PR TITLE
reduce bcm2835-v4l2 video size to reclaim some RAM

### DIFF
--- a/board/raspberrypi/overlay/etc/modules
+++ b/board/raspberrypi/overlay/etc/modules
@@ -1,4 +1,4 @@
-bcm2835-v4l2 max_video_width=2592 max_video_height=1944
+bcm2835-v4l2 max_video_width=1920 max_video_height=1200
 bcm2835-wdt
 i2c-bcm2708
 i2c-dev

--- a/board/raspberrypi2/overlay/etc/modules
+++ b/board/raspberrypi2/overlay/etc/modules
@@ -1,4 +1,4 @@
-bcm2835-v4l2 max_video_width=2592 max_video_height=1944
+bcm2835-v4l2 max_video_width=1920 max_video_height=1200
 bcm2835-wdt
 i2c-bcm2708
 i2c-dev

--- a/board/raspberrypi3/overlay/etc/modules
+++ b/board/raspberrypi3/overlay/etc/modules
@@ -1,4 +1,4 @@
-bcm2835-v4l2 max_video_width=2592 max_video_height=1944
+bcm2835-v4l2 max_video_width=1920 max_video_height=1200
 bcm2835-wdt
 i2c-bcm2708
 i2c-dev


### PR DESCRIPTION
Reduce bcm2835-v4l2 max_video_width and max_video_height to a more sensible value to reclaim some memory.

1920 width and 1200 height should cover 1920 x 1080 and 1600 x 1200 resolutions.

This PR addresses issue #1080.