### PR TITLE
Compile Motion with mmal support

### DIFF
--- a/package/motion/0002-mmal-configure-paths.patch
+++ b/package/motion/0002-mmal-configure-paths.patch
@@ -1,0 +1,48 @@
+diff --git a/configure.ac b/configure.ac
+index f14974d..368ab28 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -381,12 +381,32 @@ AS_HELP_STRING([--without-mmal],
+ WITHOUT_MMAL="yes",
+ WITHOUT_MMAL="no")
+ 
++AC_ARG_WITH(mmal-lib,
++[  --with-mmal-lib[=DIR]        Use this command to tell configure where mmal libs
++                          installation root directory is.
++                          ],
++MMAL_LIBS_DIR="$withval"
++# if not given argument, assume standard
++)
++
++AC_ARG_WITH(mmal-include,
++[  --with-mmal-include[=DIR]    Use this command to tell configure where mmal include
++                          installation root directory is.
++                          ],
++MMAL_HEADERS="$withval"
++# if not given argument, assume standard
++)
++
+ if test "${WITHOUT_MMAL}" = "no"; then
+   HAVE_MMAL=""
+   LIBRASPBERRYPIDEVPATH="/opt/vc/include/interface/mmal"
+ 
+   if test -d ${LIBRASPBERRYPIDEVPATH}; then
+        HAVE_MMAL="yes"
++       MMAL_HEADERS="/opt/vc/include"
++       MMAL_LIBS_DIR="/opt/vc/lib"
++  elif test -d ${MMAL_HEADERS}/interface/mmal; then
++       HAVE_MMAL="yes"
+   fi
+ 
+   AS_IF([test "${HAVE_MMAL}" = "yes" ], [
+@@ -394,8 +414,8 @@ if test "${WITHOUT_MMAL}" = "no"; then
+            AC_SUBST(MMAL_OBJ)
+            AC_SUBST(MMAL_LIBS)
+            MMAL_OBJ="mmalcam.o raspicam/RaspiCamControl.o raspicam/RaspiCLI.o"
+-           MMAL_CFLAGS="-std=gnu99 -DHAVE_MMAL -Irasppicam -I/opt/vc/include"
+-           MMAL_LIBS="-L/opt/vc/lib  -lmmal_core -lmmal_util -lmmal_vc_client -lvcos -lvchostif -lvchiq_arm"
++           MMAL_CFLAGS="-std=gnu99 -DHAVE_MMAL -Irasppicam -I${MMAL_HEADERS}"
++           MMAL_LIBS="-L${MMAL_LIBS_DIR}  -lmmal_core -lmmal_util -lmmal_vc_client -lvcos -lvchostif -lvchiq_arm"
+            AC_DEFINE([HAVE_MMAL], 1, [Define to 1 if we want MMAL])
+   ])
+ fi

--- a/package/motion/motion.mk
+++ b/package/motion/motion.mk
@@ -14,5 +14,12 @@ define MOTION_INSTALL_TARGET_CMDS
     cp $(@D)/motion $(TARGET_DIR)/usr/bin/motion
 endef
 
+ifeq ($(BR2_PACKAGE_RPI_USERLAND),y)
+MOTION_DEPENDENCIES += rpi-userland
+MOTION_CONF_OPTS += \
+        --with-mmal-include=$(STAGING_DIR)/usr/include \
+        --with-mmal-lib=$(STAGING_DIR)/lib
+endif
+
 $(eval $(autotools-package))
 


### PR DESCRIPTION
This will allow motion to support MMAL devices if RPi-userland is enabled. This will normally only happen on RPi devices.