### PR TITLE
Fix for unzip on OSX

### DIFF
--- a/writeimage.sh
+++ b/writeimage.sh
@@ -80,8 +80,8 @@ gunzip=$(which unpigz 2> /dev/null || which gunzip 2> /dev/null)
 
 if [[ $DISK_IMG == *.gz ]]; then
     msg "decompressing the gzipped image"
-    $gunzip -c $DISK_IMG > ${DISK_IMG::-3}
-    DISK_IMG=${DISK_IMG::-3}
+    $gunzip -c $DISK_IMG > ${DISK_IMG%???}
+    DISK_IMG=${DISK_IMG%???}
 fi
 
 umount ${SDCARD_DEV}* 2>/dev/null || true


### PR DESCRIPTION
Bash<4.2 doesn't support negative offset

OSX 10 Sierra is delivered with Bash 3.2 so it can't extract the
'.gz'-less filename for unzipping.

OSX and old Bash:
https://www.reddit.com/r/bash/comments/393oqv/why_is_the_version_of_bash_included_in_os_x_so_old/

Negativ offsets and compatibility:
http://tldp.org/LDP/abs/html/abs-guide.html#NEGOFFSET

You can create a better removal tool based on this guide:
http://tldp.org/LDP/abs/html/string-manipulation.html