### PR TITLE
script to redo data partition

### DIFF
--- a/board/common/overlay/etc/init.d/S00datapart
+++ b/board/common/overlay/etc/init.d/S00datapart
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+backup_conf="/boot/motioneyeos_config.tar.gz"
+
 test -n "$os_version" || source /etc/init.d/base
 
 case "$1" in
@@ -56,6 +58,15 @@ case "$1" in
         # mount other partitions depending on data
         mount -T /etc/fstab.disk -a
         mount -T /etc/fstab.extra -a
+
+        # restore motionEyeOS config
+        if [[ -f $backup_conf ]]; then
+            tar -C /data/etc -xf $backup_conf
+            RO=$?
+            test $RO == 0 && mount -o remount,rw /boot
+            rm -f $backup_conf
+            test $RO == 0 && mount -o remount,ro /boot
+        fi
         ;;
 
     stop)

--- a/board/common/overlay/etc/init.d/S00datapart
+++ b/board/common/overlay/etc/init.d/S00datapart
@@ -78,3 +78,4 @@ case "$1" in
         echo "Usage: $0 {start}"
         exit 1
 esac
+

--- a/board/common/overlay/etc/init.d/S00datapart
+++ b/board/common/overlay/etc/init.d/S00datapart
@@ -62,6 +62,7 @@ case "$1" in
         # restore motionEyeOS config
         if [[ -f $backup_conf ]]; then
             tar -C /data/etc -xf $backup_conf
+            grep -E "/boot .*ro[\s,]" /proc/mounts
             RO=$?
             test $RO == 0 && mount -o remount,rw /boot
             rm -f $backup_conf
@@ -77,4 +78,3 @@ case "$1" in
         echo "Usage: $0 {start}"
         exit 1
 esac
-

--- a/board/common/overlay/sbin/format_datapart
+++ b/board/common/overlay/sbin/format_datapart
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+backup_conf="/boot/motioneyeos_config.tar.gz"
+
+echo "Detecting disk device"
+root_dev=$(cat /proc/cmdline | grep -oE 'root=[/a-z0-9]+' | cut -d '=' -f 2)
+if [[ "$root_dev" =~ ^([/a-z0-9]+)(p[0-9])$ ]]; then  # e.g. /dev/mmcblk0p2
+    disk_dev=${BASH_REMATCH[1]}
+    parts_to_rm=$(fdisk -l ${disk_dev} | grep -e "^${disk_dev}p[0-9]" | grep -v -e "${disk_dev}p[1|2]" | cut -d ' ' -f 1)
+elif [[ "$root_dev" =~ ^([/a-z0-9]+)([0-9])$ ]]; then  # e.g. /dev/sdc2
+    disk_dev=${BASH_REMATCH[1]}
+    parts_to_rm=$(fdisk -l ${disk_dev} | grep -e "^${disk_dev}[0-9]" | grep -v -e "${disk_dev}[1|2]" | cut -d ' ' -f 1)
+else
+    echo "unknown ($root_dev)"
+    exit 1
+fi
+echo "$disk_dev"
+
+if [[ -d /data/etc ]]; then
+    echo "Backing up motionEyeOS configuration ..."
+    RO=$?
+    test $RO == 0 && mount -o remount,rw /boot
+    tar -czf $backup_conf -C /data/etc .
+    if [ ! $? ]; then
+        echo "Failed"
+        exit 1
+    fi
+    test $RO == 0 && mount -o remount,ro /boot
+    echo "Done"
+else
+    echo "motionEyeOS configuration not found"
+fi
+
+fdisk_cmd=""
+for part in ${parts_to_rm}; do
+    echo "Deleting partition: $part"
+    if [[ "$part" =~ ^([/a-z0-9]+)([0-9])$ ]]; then
+        part_no=${BASH_REMATCH[2]}
+        fdisk_cmd="$fdisk_cmd d
+            $part_no
+            "
+        umount -lf $part
+    fi
+done
+if [ -n "$fdisk_cmd" ]; then
+    fdisk_cmd="$fdisk_cmd w"
+    echo "$fdisk_cmd" | /sbin/fdisk $disk_dev &>/dev/null
+    echo "Rebooting"
+    reboot
+fi

--- a/board/common/overlay/sbin/format_datapart
+++ b/board/common/overlay/sbin/format_datapart
@@ -18,6 +18,7 @@ echo "$disk_dev"
 
 if [[ -d /data/etc ]]; then
     echo "Backing up motionEyeOS configuration ..."
+    grep -E "/boot .*ro[\s,]" /proc/mounts &>/dev/null
     RO=$?
     test $RO == 0 && mount -o remount,rw /boot
     tar -czf $backup_conf -C /data/etc .


### PR DESCRIPTION
Addresses issue https://github.com/ccrisan/motioneyeos/issues/1756

This PR adds a script to backup motionEyeOS /data/etc directory to boot partition, deletes the data partition, and reboots. S00datapart script now restores config on boot up, after data partition is recreated and mounted.

Does not support triggering from web interface yet, so will have to run from command line for now.

The idea is to create a temporary image that combines this PR with new partition layout S00datapart to enable users on old firmware to upgrade to latest firmware. Users first have to upgrade to this temporary image, run this format_datapart script, and finally upgrade to the latest firmware via web interface.