### PR TITLE
add AWB greyworld mode to the frontend for FNC

### DIFF
--- a/board/raspberrypi/motioneye-modules/streameyectl.py
+++ b/board/raspberrypi/motioneye-modules/streameyectl.py
@@ -58,7 +58,8 @@ AWB_CHOICES = [
     ('fluorescent', 'Fluorescent'),
     ('incandescent', 'Incandescent'),
     ('flash', 'Flash'),
-    ('horizon', 'Horizon')
+    ('horizon', 'Horizon'),
+    ('greyworld', 'Greyworld')
 ]
 
 METERING_CHOICES = [

--- a/board/raspberrypi2/motioneye-modules/streameyectl.py
+++ b/board/raspberrypi2/motioneye-modules/streameyectl.py
@@ -58,7 +58,8 @@ AWB_CHOICES = [
     ('fluorescent', 'Fluorescent'),
     ('incandescent', 'Incandescent'),
     ('flash', 'Flash'),
-    ('horizon', 'Horizon')
+    ('horizon', 'Horizon'),
+    ('greyworld', 'Greyworld')
 ]
 
 METERING_CHOICES = [

--- a/board/raspberrypi3/motioneye-modules/streameyectl.py
+++ b/board/raspberrypi3/motioneye-modules/streameyectl.py
@@ -58,7 +58,8 @@ AWB_CHOICES = [
     ('fluorescent', 'Fluorescent'),
     ('incandescent', 'Incandescent'),
     ('flash', 'Flash'),
-    ('horizon', 'Horizon')
+    ('horizon', 'Horizon'),
+    ('greyworld', 'Greyworld')
 ]
 
 METERING_CHOICES = [

--- a/board/raspberrypi4/motioneye-modules/streameyectl.py
+++ b/board/raspberrypi4/motioneye-modules/streameyectl.py
@@ -58,7 +58,8 @@ AWB_CHOICES = [
     ('fluorescent', 'Fluorescent'),
     ('incandescent', 'Incandescent'),
     ('flash', 'Flash'),
-    ('horizon', 'Horizon')
+    ('horizon', 'Horizon'),
+    ('greyworld', 'Greyworld')
 ]
 
 METERING_CHOICES = [


### PR DESCRIPTION
Allows the user to select Greyworld in FNC mode. This will only work with mjpeg streaming and not with RTSP. For RTSP, there is some work to be done since v4l2 spec does not have an enum for greyworld (https://github.com/raspberrypi/firmware/issues/1225#issuecomment-521179252).