### PR TITLE
ffmpeg: make v4l2 buffer dequeue non-blocking (zero timeout)

### DIFF
--- a/package/ffmpeg/1006-avcodec-v4l2-add-timeout-when-dequeueing-buffers.patch
+++ b/package/ffmpeg/1006-avcodec-v4l2-add-timeout-when-dequeueing-buffers.patch
@@ -15,7 +15,7 @@ index efcb0426e4..8f9420e28d 100644
       *  2. an input buffer is ready to be dequeued
       */
 -    avbuf = v4l2_dequeue_v4l2buf(ctx, -1);
-+    avbuf = v4l2_dequeue_v4l2buf(ctx, ctx_to_m2mctx(ctx)->draining ? -1 : 50);
++    avbuf = v4l2_dequeue_v4l2buf(ctx, ctx_to_m2mctx(ctx)->draining ? -1 : 0);
      if (!avbuf) {
          if (ctx->done)
              return AVERROR_EOF;
@@ -24,7 +24,7 @@ index efcb0426e4..8f9420e28d 100644
       *  2. an input buffer ready to be dequeued
       */
 -    avbuf = v4l2_dequeue_v4l2buf(ctx, -1);
-+    avbuf = v4l2_dequeue_v4l2buf(ctx, ctx_to_m2mctx(ctx)->draining ? -1 : 50);
++    avbuf = v4l2_dequeue_v4l2buf(ctx, ctx_to_m2mctx(ctx)->draining ? -1 : 0);
      if (!avbuf) {
          if (ctx->done)
              return AVERROR_EOF;


### PR DESCRIPTION
There is no point blocking the application when dequeuing buffer. If buffer is not dequeued this time, it will be dequeued next time around anyway. For this strategy to work, the application must follow the ffmpeg guidelines when receiving encoded packets, i.e. call `avcodec_receive_packet` repeatedly until EAGAIN is returned. Upstream motion currently does **NOT** follow the ffmpeg receive guideline, but we have this patch that fixes it: https://github.com/jasaw/motioneyeos/blob/xu4-hw-h264/package/motion/1001-decouple-avcodec-send-and-receive.patch
