### PR TITLE
Fix motion build dependencies

### DIFF
--- a/package/motion/Config.in
+++ b/package/motion/Config.in
@@ -2,6 +2,8 @@ config BR2_PACKAGE_MOTION
 	bool "motion"
 	depends on BR2_USE_MMU # fork()
 	depends on BR2_TOOLCHAIN_HAS_THREADS
+	select BR2_PACKAGE_FFMPEG
+	select BR2_PACKAGE_FFMPEG_SWSCALE
 	select BR2_PACKAGE_JPEG
 	select BR2_PACKAGE_LIBMICROHTTPD
 	help

--- a/package/motion/motion.mk
+++ b/package/motion/motion.mk
@@ -7,6 +7,7 @@
 MOTION_VERSION = release-4.2.2
 MOTION_SITE = $(call github,motion-project,motion,$(MOTION_VERSION))
 MOTION_AUTORECONF = YES
+MOTION_DEPENDENCIES = ffmpeg jpeg libmicrohttpd
 MOTION_CONF_OPTS = --without-pgsql \
                    --without-sdl \
                    --without-sqlite3 \

--- a/package/motion/motion.mk
+++ b/package/motion/motion.mk
@@ -7,7 +7,7 @@
 MOTION_VERSION = release-4.2.2
 MOTION_SITE = $(call github,motion-project,motion,$(MOTION_VERSION))
 MOTION_AUTORECONF = YES
-MOTION_DEPENDENCIES = ffmpeg jpeg libmicrohttpd
+MOTION_DEPENDENCIES = host-pkgconf ffmpeg jpeg libmicrohttpd
 MOTION_CONF_OPTS = --without-pgsql \
                    --without-sdl \
                    --without-sqlite3 \


### PR DESCRIPTION
MotionEyeOS's motion build assumes ffmpeg is present, so we add ffmpeg as build dependency.