### PR TITLE
RTSP FNC: enable basic auth on front-end

### DIFF
--- a/board/raspberrypi/motioneye-modules/streameyectl.py
+++ b/board/raspberrypi/motioneye-modules/streameyectl.py
@@ -1310,7 +1310,6 @@ def seAuthMode():
         'section': 'streaming',
         'camera': True,
         'required': True,
-        'depends': ['seProto==mjpeg'],
         'get': _get_streameye_settings,
         'set': _set_streameye_settings,
         'get_set_dict': True

--- a/board/raspberrypi2/motioneye-modules/streameyectl.py
+++ b/board/raspberrypi2/motioneye-modules/streameyectl.py
@@ -1310,7 +1310,6 @@ def seAuthMode():
         'section': 'streaming',
         'camera': True,
         'required': True,
-        'depends': ['seProto==mjpeg'],
         'get': _get_streameye_settings,
         'set': _set_streameye_settings,
         'get_set_dict': True

--- a/board/raspberrypi3/motioneye-modules/streameyectl.py
+++ b/board/raspberrypi3/motioneye-modules/streameyectl.py
@@ -1310,7 +1310,6 @@ def seAuthMode():
         'section': 'streaming',
         'camera': True,
         'required': True,
-        'depends': ['seProto==mjpeg'],
         'get': _get_streameye_settings,
         'set': _set_streameye_settings,
         'get_set_dict': True

--- a/board/raspberrypi4/motioneye-modules/streameyectl.py
+++ b/board/raspberrypi4/motioneye-modules/streameyectl.py
@@ -1310,7 +1310,6 @@ def seAuthMode():
         'section': 'streaming',
         'camera': True,
         'required': True,
-        'depends': ['seProto==mjpeg'],
         'get': _get_streameye_settings,
         'set': _set_streameye_settings,
         'get_set_dict': True


### PR DESCRIPTION
Allow basic auth to be selectable from the web front-end.