### PR TITLE
Temporary motion patches to fix playback issues encoded via XU4 h264_v4l2m2m

### DIFF
--- a/package/motion/2000-do-not-encode-nal-as-first-frame.patch
+++ b/package/motion/2000-do-not-encode-nal-as-first-frame.patch
@@ -1,0 +1,75 @@
+commit 6c47f0cded1ef1f119f91f2c6f572d6620776dff
+Author: Joo Aun Saw <jasaw@dius.com.au>
+Date:   Wed Oct 23 10:45:13 2019 +1100
+
+    ffmpeg: do not encode NAL as the first video frame
+
+diff --git a/src/ffmpeg.c b/src/ffmpeg.c
+index 3af961a..76f3824 100644
+--- a/src/ffmpeg.c
++++ b/src/ffmpeg.c
+@@ -192,16 +192,17 @@ static void ffmpeg_free_nal(struct ffmpeg *ffmpeg){
+     }
+ }
+ 
+-static void ffmpeg_encode_nal(struct ffmpeg *ffmpeg){
++static int ffmpeg_encode_nal(struct ffmpeg *ffmpeg){
+     // h264_v4l2m2m has NAL units separated from the first frame, which makes
+     // some players very unhappy.
+     if ((ffmpeg->pkt.pts == 0) && (!(ffmpeg->pkt.flags & AV_PKT_FLAG_KEY))) {
+         ffmpeg_free_nal(ffmpeg);
+         ffmpeg->nal_info_len = ffmpeg->pkt.size;
+         ffmpeg->nal_info = malloc(ffmpeg->nal_info_len);
+-        if (ffmpeg->nal_info)
++        if (ffmpeg->nal_info) {
+             memcpy(ffmpeg->nal_info, &ffmpeg->pkt.data[0], ffmpeg->nal_info_len);
+-        else
++            return 1;
++        } else
+             ffmpeg->nal_info_len = 0;
+     } else if (ffmpeg->nal_info) {
+         int old_size = ffmpeg->pkt.size;
+@@ -210,6 +211,7 @@ static void ffmpeg_encode_nal(struct ffmpeg *ffmpeg){
+         memcpy(&ffmpeg->pkt.data[0], ffmpeg->nal_info, ffmpeg->nal_info_len);
+         ffmpeg_free_nal(ffmpeg);
+     }
++    return 0;
+ }
+ 
+ static int ffmpeg_timelapse_exists(const char *fname){
+@@ -463,7 +465,10 @@ static int ffmpeg_encode_video(struct ffmpeg *ffmpeg){
+     }
+ 
+     if (ffmpeg->preferred_codec == USER_CODEC_V4L2M2M){
+-        ffmpeg_encode_nal(ffmpeg);
++        if (ffmpeg_encode_nal(ffmpeg)) {
++            // Throw special return code
++            return -2;
++        }
+     }
+ 
+     return 0;
+@@ -489,7 +494,10 @@ static int ffmpeg_encode_video(struct ffmpeg *ffmpeg){
+ 
+     /* This kills compiler warnings.  Nal setting is only for recent ffmpeg versions*/
+     if (ffmpeg->preferred_codec == USER_CODEC_V4L2M2M){
+-        ffmpeg_encode_nal(ffmpeg);
++        if (ffmpeg_encode_nal(ffmpeg)) {
++            // Throw special return code
++            return -2;
++        }
+     }
+ 
+     return 0;
+@@ -529,7 +537,10 @@ static int ffmpeg_encode_video(struct ffmpeg *ffmpeg){
+ 
+     /* This kills compiler warnings.  Nal setting is only for recent ffmpeg versions*/
+     if (ffmpeg->preferred_codec == USER_CODEC_V4L2M2M){
+-        ffmpeg_encode_nal(ffmpeg);
++        if (ffmpeg_encode_nal(ffmpeg)) {
++            // Throw special return code
++            return -2;
++        }
+     }
+ 
+     return 0;

--- a/package/motion/2001-fix-video-initial-pts.patch
+++ b/package/motion/2001-fix-video-initial-pts.patch
@@ -1,0 +1,19 @@
+commit 54030816e03a31b8af3c53132636bb9bb97b0673
+Author: Joo Aun Saw <jasaw@dius.com.au>
+Date:   Wed Oct 23 00:55:31 2019 +1100
+
+    use current frame timestamp as movie initial PTS reference point
+
+diff --git a/src/motion.c b/src/motion.c
+index e394c19..9d3cd24 100644
+--- a/src/motion.c
++++ b/src/motion.c
+@@ -536,7 +536,7 @@ static void motion_detected(struct context *cnt, int dev, struct image_data *img
+ 
+             /* EVENT_FIRSTMOTION triggers on_event_start_command and event_ffmpeg_newfile */
+             event(cnt, EVENT_FIRSTMOTION, img, NULL, NULL,
+-                &cnt->imgs.image_ring[cnt->imgs.image_ring_out].timestamp_tv);
++                &img->timestamp_tv);
+ 
+             MOTION_LOG(NTC, TYPE_ALL, NO_ERRNO, _("Motion detected - starting event %d"),
+                        cnt->event_nr);


### PR DESCRIPTION
This PR includes 2 patches:
1. motion: do not encode NAL as first frame. https://github.com/Motion-Project/motion/pull/1045
2. motion: fix video initial PTS. https://github.com/Motion-Project/motion/pull/1044
