### PR TITLE
FND RTSP: do not use mjpeg resolution config when in RTSP mode

### DIFF
--- a/board/raspberrypi/overlay/usr/bin/streameye.sh
+++ b/board/raspberrypi/overlay/usr/bin/streameye.sh
@@ -114,7 +114,7 @@ function start() {
         fi
         modprobe v4l2loopback video_nr=${vidid}
         if [ -e "${video_path}" ]; then
-            valid_opts=("analoggain" "awb" "awbgains" "bitrate" "brightness" "colfx" "contrast" "denoise" "digitalgain" "drc" "ev" "exposure" "flicker" "framerate" "height" "hflip" "imxfx" "intra" "irefresh" "level" "metering" "profile" "roi" "rotation" "saturation" "sharpness" "shutter" "vflip" "vstab" "width" "mjpegbitrate" "mjpegframerate" "mjpegwidth" "mjpegheight")
+            valid_opts=("analoggain" "awb" "awbgains" "bitrate" "brightness" "colfx" "contrast" "denoise" "digitalgain" "drc" "ev" "exposure" "flicker" "framerate" "hflip" "imxfx" "intra" "irefresh" "level" "metering" "profile" "roi" "rotation" "saturation" "sharpness" "shutter" "vflip" "vstab" "mjpegbitrate" "mjpegframerate" "mjpegwidth" "mjpegheight")
             raspimjpeg_opts="--videoout ${video_path}"
             while read line; do
                 key=$(echo ${line} | cut -d ' ' -f 1)

--- a/board/raspberrypi2/overlay/usr/bin/streameye.sh
+++ b/board/raspberrypi2/overlay/usr/bin/streameye.sh
@@ -114,7 +114,7 @@ function start() {
         fi
         modprobe v4l2loopback video_nr=${vidid}
         if [ -e "${video_path}" ]; then
-            valid_opts=("analoggain" "awb" "awbgains" "bitrate" "brightness" "colfx" "contrast" "denoise" "digitalgain" "drc" "ev" "exposure" "flicker" "framerate" "height" "hflip" "imxfx" "intra" "irefresh" "level" "metering" "profile" "roi" "rotation" "saturation" "sharpness" "shutter" "vflip" "vstab" "width" "mjpegbitrate" "mjpegframerate" "mjpegwidth" "mjpegheight")
+            valid_opts=("analoggain" "awb" "awbgains" "bitrate" "brightness" "colfx" "contrast" "denoise" "digitalgain" "drc" "ev" "exposure" "flicker" "framerate" "hflip" "imxfx" "intra" "irefresh" "level" "metering" "profile" "roi" "rotation" "saturation" "sharpness" "shutter" "vflip" "vstab" "mjpegbitrate" "mjpegframerate" "mjpegwidth" "mjpegheight")
             raspimjpeg_opts="--videoout ${video_path}"
             while read line; do
                 key=$(echo ${line} | cut -d ' ' -f 1)

--- a/board/raspberrypi3/overlay/usr/bin/streameye.sh
+++ b/board/raspberrypi3/overlay/usr/bin/streameye.sh
@@ -114,7 +114,7 @@ function start() {
         fi
         modprobe v4l2loopback video_nr=${vidid}
         if [ -e "${video_path}" ]; then
-            valid_opts=("analoggain" "awb" "awbgains" "bitrate" "brightness" "colfx" "contrast" "denoise" "digitalgain" "drc" "ev" "exposure" "flicker" "framerate" "height" "hflip" "imxfx" "intra" "irefresh" "level" "metering" "profile" "roi" "rotation" "saturation" "sharpness" "shutter" "vflip" "vstab" "width" "mjpegbitrate" "mjpegframerate" "mjpegwidth" "mjpegheight")
+            valid_opts=("analoggain" "awb" "awbgains" "bitrate" "brightness" "colfx" "contrast" "denoise" "digitalgain" "drc" "ev" "exposure" "flicker" "framerate" "hflip" "imxfx" "intra" "irefresh" "level" "metering" "profile" "roi" "rotation" "saturation" "sharpness" "shutter" "vflip" "vstab" "mjpegbitrate" "mjpegframerate" "mjpegwidth" "mjpegheight")
             raspimjpeg_opts="--videoout ${video_path}"
             while read line; do
                 key=$(echo ${line} | cut -d ' ' -f 1)

--- a/board/raspberrypi4/overlay/usr/bin/streameye.sh
+++ b/board/raspberrypi4/overlay/usr/bin/streameye.sh
@@ -114,7 +114,7 @@ function start() {
         fi
         modprobe v4l2loopback video_nr=${vidid}
         if [ -e "${video_path}" ]; then
-            valid_opts=("analoggain" "awb" "awbgains" "bitrate" "brightness" "colfx" "contrast" "denoise" "digitalgain" "drc" "ev" "exposure" "flicker" "framerate" "height" "hflip" "imxfx" "intra" "irefresh" "level" "metering" "profile" "roi" "rotation" "saturation" "sharpness" "shutter" "vflip" "vstab" "width" "mjpegbitrate" "mjpegframerate" "mjpegwidth" "mjpegheight")
+            valid_opts=("analoggain" "awb" "awbgains" "bitrate" "brightness" "colfx" "contrast" "denoise" "digitalgain" "drc" "ev" "exposure" "flicker" "framerate" "hflip" "imxfx" "intra" "irefresh" "level" "metering" "profile" "roi" "rotation" "saturation" "sharpness" "shutter" "vflip" "vstab" "mjpegbitrate" "mjpegframerate" "mjpegwidth" "mjpegheight")
             raspimjpeg_opts="--videoout ${video_path}"
             while read line; do
                 key=$(echo ${line} | cut -d ' ' -f 1)


### PR DESCRIPTION
Oops, just discovered that in RTSP mode, `streameye.sh` includes height and width args twice, once from mjpeg resolution, another time from RTSP resolution. It makes no difference functionally because RTSP resolution args come after the mjpeg resolution args which overwrites the mjpeg resolution, but it should be cleaned up.