### PR TITLE
Add docker build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+from ubuntu:18.04
+
+USER root
+
+RUN \
+    apt-get update -q && \
+    DEBIAN_FRONTEND="noninteractive" apt-get install -qy --fix-missing --no-install-recommends \
+      ca-certificates \
+      build-essential \
+      #fakeroot \
+      git \
+      wget \
+      curl \
+      file \
+      python2.7-dev \
+      python3-dev \
+      libssl-dev \
+      libncurses5-dev \
+      rsync \
+      patch \
+      cpio \
+      gzip \
+      unzip \
+      bc \
+      openssh-client \
+      asciidoc \
+      dblatex \
+      graphviz \
+      python-matplotlib && \
+    rm -rf /var/lib/apt/lists/*  && \
+    useradd -ms /bin/bash build && \
+    mkdir -p /build && \
+    chown -R build:build  /build
+
+USER build
+
+WORKDIR /build
+
+# container just waits, by default, actual builds can be done with `docker exec`
+CMD /bin/bash -c 'for ((i = 0; ; i++)); do sleep 100; done'

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+IMAGE_NAME=motioneyeos-builder
+SHOW_USAGE=false
+
+while true
+do
+  case "$1" in
+    -i|--image) if [ $# -lt 2 ]; then SHOW_USAGE=true; else IMAGE_NAME=$2; shift; fi; shift;;
+    --image) if [ $# -lt 2 ]; then SHOW_USAGE=true; else IMAGE_NAME=$2; shift; fi; shift;;
+    -?|-h|--help) SHOW_USAGE="true"; shift;;
+    *) break;;
+  esac
+done
+
+if [ "${SHOW_USAGE}" = "true" ]; then
+  echo "Usage: $0 [-i|--image <image-tag>]"
+  echo "    builds a docker image based on Ubuntu 18.04 for building motioneyeos"
+  echo "    default image name is 'motioneyeos-builder'"
+  exit 1
+fi
+
+docker build -t "${IMAGE_NAME}" .
+

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+IMAGE_NAME=motioneyeos-builder
+CONTAINER_NAME=""
+SHOW_USAGE=false
+
+while true
+do
+  case "$1" in
+    -i|--image) if [ $# -lt 2 ]; then SHOW_USAGE=true; else IMAGE_NAME=$2; shift; fi; shift;;
+    -c|--container) if [ $# -lt 2 ]; then SHOW_USAGE=true; else CONTAINER_NAME=$2; shift; fi; shift;;
+    -?|-h|--help) SHOW_USAGE="true"; shift;;
+    *) break;;
+  esac
+done
+
+if [ "${SHOW_USAGE}" = "true" ]; then
+  echo "Usage: $0 [-i|--image <image-tag>]  [-c|--container <container-name>] <args>"
+  echo "    -i | --image: Docker image to use (default image name is 'motioneyeos-builder')"
+  echo "    -c | --container: Name for Docker container (defaults to image name with a randome integer appended"
+  echo "    causes a docker image to build motioneyeos in a docker container"
+  exit 1
+fi
+
+if [ "${CONTAINER_NAME}" = "" ]; then
+  CONTAINER_NAME="${IMAGE_NAME}-${RANDOM}"
+fi
+
+docker run --rm --name "${CONTAINER_NAME}" --mount type=bind,src=${PWD},target=/build -it "${IMAGE_NAME}" ./build.sh "$@"


### PR DESCRIPTION
Scripts to create and build with a docker image based on Ubuntu 18.04. This really helps when dealing with various build platform compatibility issues, I could find now way to build under arch because of too many tools having issues with the code base, so this puts the entire build chain under Ubuntu 18.04, which works fine