### PR TITLE
Optionally automatically fsck data paritition on boot

### DIFF
--- a/board/common/overlay/etc/init.d/S00datapart
+++ b/board/common/overlay/etc/init.d/S00datapart
@@ -23,7 +23,14 @@ case "$1" in
         fi
         msg_done "${disk_dev}"
 
-        test -b ${data_dev} && exit 0
+        if [ -b ${data_dev} ]
+        then
+            if grep -q 'fsck.mode=force' /proc/cmdline
+            then
+                /sbin/e2fsck -fy ${data_dev}
+            fi
+            exit 0
+        fi
 
         msg_begin "Creating data partition"
         data_start=$((DATA_OFFS * 2048))


### PR DESCRIPTION
One of my raspberry pi cameras was stuck in a boot loop due to a corrupt /data partition, I wanted to run fsck on boot but the normal command line parameters don't appear to work so I added this small change to check /data on boot if configured via /boot/cmdline.txt

This checks for the fsck.mode=force parameter in /proc/cmdline if it's present then it will run e2fsck -fy on the data partition before mounting it.