### PR TITLE
Enable serial console output and login for odroidxu4

### DIFF
--- a/board/odroidxu4/boot.ini
+++ b/board/odroidxu4/boot.ini
@@ -2,6 +2,6 @@ ODROIDXU-UBOOT-CONFIG
 
 setenv fdt_high "0xffffffff"
 setenv bootcmd "fatload mmc 0:1 0x40008000 zImage; fatload mmc 0:1 0x42000000 uInitrd; fatload mmc 0:1 0x44000000 exynos5422-odroidxu4.dtb; bootz 0x40008000 - 0x44000000"
-setenv bootargs "console=tty1 root=/dev/mmcblk1p2 rootwait ro no_console_suspend panic=10 quiet loglevel=1"
+setenv bootargs "console=tty1 console=ttySAC2,115200n8 root=/dev/mmcblk1p2 rootwait ro no_console_suspend panic=10 quiet loglevel=1"
 boot
 

--- a/board/odroidxu4/postscript.sh
+++ b/board/odroidxu4/postscript.sh
@@ -15,3 +15,4 @@ cp ${IMG_DIR}/exynos5422-odroidxu4.dtb ${BOOT_DIR}
 cp ${BOARD_DIR}/boot.ini ${BOOT_DIR}
 cp ${BOARD_DIR}/uInitrd ${BOOT_DIR}
 
+sed -i '/^ttylogin::respawn:\/sbin\/getty -L ttylogin 115200 vt100/a\ttylogin::respawn:\/sbin\/getty -L ttySAC2 115200 vt100'  ${TARGET}/etc/inittab


### PR DESCRIPTION
This enables the serial console for the Odroid XU4 boards.  I tested this on my Odroid HC1.