### PR TITLE
xrange() was removed from Python

### DIFF
--- a/package/motioneye/ipctl.py
+++ b/package/motioneye/ipctl.py
@@ -80,7 +80,7 @@ def _get_ip_settings():
         ip = '192.168.1.101'
 
     bits = 0
-    for i in xrange(32 - int(cidr), 32):
+    for i in range(32 - int(cidr), 32):
         bits |= (1 << i)
     
     mask = '%d.%d.%d.%d' % ((bits & 0xff000000) >> 24, (bits & 0xff0000) >> 16, (bits & 0xff00) >> 8 , (bits & 0xff))


### PR DESCRIPTION
https://portingguide.readthedocs.io/en/latest/iterators.html#new-behavior-of-range