### PR TITLE
Wiki: Supported Devices: Corrections and merges from ccrisan/thingos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 **motionEyeOS** is a Linux distribution that turns your single board computer into a video surveillance system. Check out the [wiki](https://github.com/ccrisan/motioneyeos/wiki) for more details.
 
-Due to personal reasons I can no longer be actively involved with this project. If anyone is interested in taking it over, please contact me and we'll work out together a hand-off plan.
+Due to personal reasons I can no longer be actively involved with this project. If anyone is interested in taking it over, please contact me and we'll work out together a hand-off plan, see also [my last comment about the next plans this project](https://github.com/motioneye-project/motioneyeos/commit/d816a04b36cd007083955d3149fa4179e8690415#commitcomment-68581119).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 **motionEyeOS** is a Linux distribution that turns your single board computer into a video surveillance system. Check out the [wiki](https://github.com/ccrisan/motioneyeos/wiki) for more details.
 
-Due to personal reasons I can no longer be actively involved with this project. If anyone is interested in taking it over, please contact me and we'll work out together a hand-off plan, see also [my last comment about the next plans this project](https://github.com/motioneye-project/motioneyeos/commit/d816a04b36cd007083955d3149fa4179e8690415#commitcomment-68581119).
+Due to personal reasons I can no longer be actively involved with this project. If anyone is interested in taking it over, please contact me and we'll work out together a hand-off plan, see also [my last comment about the next plans for this project](https://github.com/motioneye-project/motioneyeos/commit/d816a04b36cd007083955d3149fa4179e8690415#commitcomment-68581119).

--- a/wiki-edits/Supported-Devices.md
+++ b/wiki-edits/Supported-Devices.md
@@ -1,0 +1,71 @@
+### Banana PI M1
+
+* [board home page](http://www.banana-pi.org/m1.html)
+* latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-bananapim1-20200606.img.xz)
+* kernel: 4.4 (vanilla)
+
+### Nano Pi Neo2
+
+ * [board home page](http://www.friendlyarm.com/index.php?route=product/product&product_id=180)
+ * latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-nanopineo2-20200606.img.xz)
+ * kernel 4.11 (friendlyarm)
+
+### Odroid C1/C1+
+
+* [board home page](http://www.hardkernel.com/main/products/prdt_info.php?g_code=G141578608433)
+* latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-odroidc1-20200606.img.xz)
+* kernel: 3.10 (hardkernel)
+
+### Odroid C2
+
+* [board home page](http://www.hardkernel.com/main/products/prdt_info.php?g_code=G145457216438)
+* latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-odroidc2-20200606.img.xz)
+* kernel: 3.16 (hardkernel)
+
+### Odroid XU4/XU4Q/HC1/HC2/MC1
+
+* [board home page](http://www.hardkernel.com/main/products/prdt_info.php?g_code=G143452239825)
+* latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-odroidxu4-20200606.img.xz)
+* kernel: 4.14 (hardkernel)
+
+### Orange Pi One
+
+ * [board home page](http://www.orangepi.org/orangepione/)
+ * latest version: [2020200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-orangepione-20200606.img.xz)
+ * kernel 4.14 (megous)
+
+### Pine A64/A64+
+
+* [board home page](https://www.pine64.org/)
+* latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-pine64-20200606.img.xz)
+* kernel: 3.10 (longsleep)
+
+### Raspberry PI (A, B, A+, B+, Compute Module, Zero and Zero W models)
+
+* [board home page](http://www.raspberrypi.org)
+* latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-raspberrypi-20200606.img.xz)
+* kernel: 4.19 (raspbian)
+
+### Raspberry PI 2
+
+* [board home page](http://www.raspberrypi.org)
+* latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-raspberrypi2-20200606.img.xz)
+* kernel: 4.19 (raspbian)
+
+### Raspberry PI 3 (B, B+, A+, Compute Module 3)
+
+* [board home page](http://www.raspberrypi.org)
+* latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-raspberrypi3-20200606.img.xz)
+* kernel: 4.19 (raspbian)
+
+### Raspberry PI 4
+
+* [board home page](http://www.raspberrypi.org)
+* latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-raspberrypi4-20200606.img.xz)
+* kernel: 4.19 (raspbian)
+
+### Tinker Board
+
+* [board home page] (https://www.asus.com/us/Single-Board-Computer/Tinker-Board/)
+* latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-tinkerboard-20200606.img.xz)
+* kernel: (unknown)

--- a/wiki-edits/Supported-Devices.md
+++ b/wiki-edits/Supported-Devices.md
@@ -1,6 +1,6 @@
 ### Banana PI M1
 
-* [board home page](http://www.bananapi.org/p/product.html)
+* [board home page](https://www.banana-pi.org/en/banana-pi-sbcs/10.html)
 * latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-bananapim1-20200606.img.xz)
 * kernel: 4.4 (vanilla)
 

--- a/wiki-edits/Supported-Devices.md
+++ b/wiki-edits/Supported-Devices.md
@@ -1,37 +1,43 @@
 ### Banana PI M1
 
-* [board home page](http://www.banana-pi.org/m1.html)
+* [board home page](http://www.bananapi.org/p/product.html)
 * latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-bananapim1-20200606.img.xz)
 * kernel: 4.4 (vanilla)
 
 ### Nano Pi Neo2
 
- * [board home page](http://www.friendlyarm.com/index.php?route=product/product&product_id=180)
+ * [board home page](https://wiki.friendlyelec.com/wiki/index.php/NanoPi_NEO2)
  * latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-nanopineo2-20200606.img.xz)
  * kernel 4.11 (friendlyarm)
 
 ### Odroid C1/C1+
 
-* [board home page](http://www.hardkernel.com/main/products/prdt_info.php?g_code=G141578608433)
+* [board home page](https://www.hardkernel.com/shop/odroid-c1)
 * latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-odroidc1-20200606.img.xz)
 * kernel: 3.10 (hardkernel)
 
 ### Odroid C2
 
-* [board home page](http://www.hardkernel.com/main/products/prdt_info.php?g_code=G145457216438)
+* [board home page](https://www.hardkernel.com/shop/odroid-c2)
 * latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-odroidc2-20200606.img.xz)
 * kernel: 3.16 (hardkernel)
 
 ### Odroid XU4/XU4Q/HC1/HC2/MC1
 
-* [board home page](http://www.hardkernel.com/main/products/prdt_info.php?g_code=G143452239825)
+* board home pages:
+  [XU4](https://www.hardkernel.com/shop/odroid-xu4-special-price),
+  [XU4Q](https://www.hardkernel.com/shop/odroid-xu4q-special-price),
+  [HC1](https://web.archive.org/web/20180823224437/https://www.hardkernel.com/main/products/prdt_info.php?g_code=G150229074080),
+  [HC2](https://web.archive.org/web/20180609152620/http://www.hardkernel.com/main/products/prdt_info.php?g_code=G151505170472),
+  [MC1](https://web.archive.org/web/20181028104325/http://www.hardkernel.com/main/products/prdt_info.php?g_code=G150152508314)
+
 * latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-odroidxu4-20200606.img.xz)
 * kernel: 4.14 (hardkernel)
 
 ### Orange Pi One
 
- * [board home page](http://www.orangepi.org/orangepione/)
- * latest version: [2020200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-orangepione-20200606.img.xz)
+ * [board home page](http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-One.html)
+ * latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-orangepione-20200606.img.xz)
  * kernel 4.14 (megous)
 
 ### Pine A64/A64+
@@ -66,6 +72,6 @@
 
 ### Tinker Board
 
-* [board home page] (https://www.asus.com/us/Single-Board-Computer/Tinker-Board/)
+* [board home page](https://www.asus.com/us/Single-Board-Computer/Tinker-Board/)
 * latest version: [20200606](https://github.com/ccrisan/motioneyeos/releases/download/20200606/motioneyeos-tinkerboard-20200606.img.xz)
 * kernel: (unknown)


### PR DESCRIPTION
Dear maintainer, please use only the commits 7895db0 and b32ed31, see [Warning](#Warning).

# Update dead links of board home pages
## Merges from [ccrisan/thingos: wiki](https://github.com/ccrisan/thingos/wiki/Supported-Single-Board-Computers)
- Nano Pi Neo2 (additionally update changed domain like redirect)

## Own link updates
- Banana PI M1 (see comment in b32ed31)
- Odroid C1/C1+
- Odroid C2
- Odroid XU4/XU4Q/HC1/HC2/MC1
- Orange Pi One

## Correction of wrong markdown syntax of link
- Tinker Board

## Tests
I have tested all the links, they all work now.

# Correction of latest version number
- Orange Pi One

<a name="Warning">**Warning**</a>: This pull request unintentionally includes the changes of #2997, as I just started after d9feb0d using a feature branch. But, this is probably not a problem, as this commit will never be merged, as stated by @cclauss in [motioneye/issues/2307#issuecomment-1595300553](https://github.com/motioneye-project/motioneye/issues/2307#issuecomment-1595300553) (?)