### PR TITLE
Raspberry Pi 4 Model B - rpi4-rev15-firmware-bump

### DIFF
--- a/board/raspberrypi4/config.txt
+++ b/board/raspberrypi4/config.txt
@@ -1,5 +1,19 @@
 gpu_mem=128
 
+# The boot files are installed under generic names (see postscript.sh), so name
+# them explicitly rather than relying on the firmware's start4.elf/fixup4.dat ->
+# start.elf/fixup.dat fallback.
+start_file=start.elf
+fixup_file=fixup.dat
+kernel=kernel.img
+
+# This is a 32-bit (armhf) build. Newer firmware defaults arm_64bit=1 on BCM2711
+# and would look for kernel8.img, so pin it off.
+arm_64bit=0
+
+# Firmware-stage output on the UART, to make boot failures diagnosable.
+enable_uart=1
+
 dtparam=i2c_arm=on
 dtparam=i2s=on
 dtparam=spi=on

--- a/package/rpi-firmware/rpi-firmware.hash
+++ b/package/rpi-firmware/rpi-firmware.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256  33aea2cb9c3be94c3dd6a96fbb3443eee5af1dc5fc9140e1fadc50832983064e  rpi-firmware-3f20b832b27cd730deb6419b570f31a98167eef6.tar.gz
+sha256  4761039a267a866bc163e55a43e6994862f66665b7b95016aec4d07a882ef5aa  rpi-firmware-191360eaf2e5933eaa0ed76ac0d62722b6f9a58f.tar.gz
 sha256  c7283ff51f863d93a275c66e3b4cb08021a5dd4d8c1e7acc47d872fbe52d3d6b  boot/LICENCE.broadcom

--- a/package/rpi-firmware/rpi-firmware.mk
+++ b/package/rpi-firmware/rpi-firmware.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_FIRMWARE_VERSION = 3f20b832b27cd730deb6419b570f31a98167eef6
+RPI_FIRMWARE_VERSION = 191360eaf2e5933eaa0ed76ac0d62722b6f9a58f
 RPI_FIRMWARE_SITE = $(call github,raspberrypi,firmware,$(RPI_FIRMWARE_VERSION))
 RPI_FIRMWARE_LICENSE = BSD-3-Clause
 RPI_FIRMWARE_LICENSE_FILES = boot/LICENCE.broadcom


### PR DESCRIPTION
Manage to boot and running under Raspberry Pi 4 Model B 